### PR TITLE
feature/MIG-6510 Create diagram types

### DIFF
--- a/src/components/diagram.test.tsx
+++ b/src/components/diagram.test.tsx
@@ -6,7 +6,7 @@ describe('Diagram', () => {
   it('Should render diagram', () => {
     render(
       <ReactFlowProvider>
-        <Diagram title={'MongoDB Diagram'} />
+        <Diagram title={'MongoDB Diagram'} nodes={[]} edges={[]} />
       </ReactFlowProvider>,
     );
     expect(screen.getByTitle('MongoDB Diagram')).toBeInTheDocument();

--- a/src/components/diagram.tsx
+++ b/src/components/diagram.tsx
@@ -1,15 +1,11 @@
 import { Canvas } from '@/components/canvas/canvas';
 import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
-import { ComponentProps } from 'react';
 import { DARK_THEME } from '@/styles/theme-dark';
 import { LIGHT_THEME } from '@/styles/theme-light';
 import { ThemeProvider } from '@emotion/react';
+import { DiagramProps } from '@/types/component-props';
 
-interface Props extends ComponentProps<typeof Canvas> {
-  isDarkMode?: boolean;
-}
-
-export const Diagram = ({ isDarkMode, ...rest }: Props) => {
+export const Diagram = ({ isDarkMode, ...rest }: DiagramProps) => {
   return (
     <ThemeProvider theme={isDarkMode ? DARK_THEME : LIGHT_THEME}>
       <LeafyGreenProvider darkMode={isDarkMode}>

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -1,0 +1,11 @@
+import { ReactFlowProps } from 'reactflow';
+import { Edge } from '@/types/edge';
+import { Node } from '@/types/node';
+
+type BaseProps = Pick<ReactFlowProps, 'title'>;
+
+export interface DiagramProps extends BaseProps {
+  isDarkMode?: boolean;
+  nodes: Array<Node>;
+  edges: Array<Edge>;
+}

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -1,0 +1,10 @@
+import { Edge as ReactFlowEdge } from 'reactflow';
+
+type BaseEdgeProps = Pick<ReactFlowEdge, 'id' | 'type' | 'source' | 'target' | 'hidden' | 'selected'>;
+
+type Marker = 'one' | 'many' | 'oneOrMany';
+
+export interface Edge extends BaseEdgeProps {
+  markerStart: Marker;
+  markerEnd: Marker;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './component-props';
+export * from './edge';
+export * from './node';

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -1,0 +1,23 @@
+import { Node as ReactFlowNode } from 'reactflow';
+
+type BaseNodeProps = Pick<
+  ReactFlowNode,
+  'id' | 'type' | 'position' | 'hidden' | 'draggable' | 'selected' | 'style' | 'className'
+>;
+
+type NodeFieldVariant = 'dimmed' | 'preview' | 'default';
+type NodeGlyph = 'key' | 'link';
+
+export interface NodeField {
+  name: string;
+  type?: string;
+  depth?: number;
+  glyphs?: NodeGlyph;
+  variant?: NodeFieldVariant;
+}
+
+export interface Node extends BaseNodeProps {
+  title: string;
+  fields: Array<NodeField>;
+  borderVariant?: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
     react(),
     dts({
       rollupTypes: true,
-      exclude: ['./node_modules'],
+      exclude: ['./node_modules', 'src/**/*.test.(tsx|ts)', 'src/**/*.stories.(tsx|ts)'],
       tsconfigPath: './tsconfig.json',
     }),
     svgrPlugin(),


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: MIG-6510
- :art: [Figma](https://www.figma.com/files/)

## Description

* Creates diagram types according to the [tech design](https://docs.google.com/document/d/1UlSgn4UxWNz90E8Dd44r64UZvntkZwx56zQgmTnYtww/edit?tab=t.0#heading=h.dz9ixrm98tk5)
* Doing this allows us to unblock [MIG-6411](https://jira.mongodb.org/browse/MIG-6411)