### PR TITLE
feature/MIG-6579 Add preview state to the fields

### DIFF
--- a/src/components/field/field-depth.tsx
+++ b/src/components/field/field-depth.tsx
@@ -1,11 +1,10 @@
 import styled from '@emotion/styled';
-import { spacing } from '@leafygreen-ui/tokens';
 import { palette } from '@leafygreen-ui/palette';
 
-import { DEFAULT_FIELD_HEIGHT } from '@/utilities/constants';
+import { DEFAULT_DEPTH_SPACING, DEFAULT_FIELD_HEIGHT } from '@/utilities/constants';
 
 const FieldDepthWrapper = styled.div`
-  padding-right: ${spacing[200]}px;
+  padding-right: ${DEFAULT_DEPTH_SPACING}px;
   height: ${DEFAULT_FIELD_HEIGHT}px;
   border-left: 1px solid ${palette.gray.dark2};
 `;

--- a/src/components/field/field-list.tsx
+++ b/src/components/field/field-list.tsx
@@ -3,6 +3,7 @@ import { spacing } from '@leafygreen-ui/tokens';
 
 import { Field } from '@/components/field/field';
 import { NodeField } from '@/types';
+import { getPreviewGroupLengths } from '@/utilities/get-preview-group-lengths';
 
 const NodeFieldWrapper = styled.div`
   padding: ${spacing[200]}px ${spacing[400]}px ${spacing[200]}px ${spacing[400]}px;
@@ -16,6 +17,7 @@ interface Props {
 
 export const FieldList = ({ fields, accent }: Props) => {
   const spacing = Math.max(0, ...fields.map(field => field.glyphs?.length || 0));
+  const previewGroupLength = getPreviewGroupLengths(fields);
   return (
     <NodeFieldWrapper>
       {fields.map(({ name, type: fieldType, depth, glyphs, variant }) => (
@@ -23,6 +25,7 @@ export const FieldList = ({ fields, accent }: Props) => {
           key={name}
           name={name}
           depth={depth}
+          previewGroupLength={previewGroupLength[name]}
           accent={accent}
           glyphs={glyphs}
           type={fieldType}

--- a/src/components/field/field.tsx
+++ b/src/components/field/field.tsx
@@ -4,10 +4,13 @@ import { palette } from '@leafygreen-ui/palette';
 import Icon from '@leafygreen-ui/icon';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 
-import { ellipsisTruncation } from '@/styles/styles';
-import { DEFAULT_FIELD_HEIGHT } from '@/utilities/constants';
+import { animatedBlueBorder, ellipsisTruncation } from '@/styles/styles';
+import { DEFAULT_DEPTH_SPACING, DEFAULT_FIELD_HEIGHT } from '@/utilities/constants';
 import { FieldDepth } from '@/components/field/field-depth';
 import { NodeField, NodeGlyph } from '@/types';
+
+const FIELD_BORDER_ANIMATED_PADDING = spacing[100];
+const FIELD_GLYPH_SPACING = spacing[400];
 
 const GlyphToIcon: Record<NodeGlyph, string> = {
   key: 'Key',
@@ -26,7 +29,37 @@ const InnerFieldWrapper = styled.div<{ width: number }>`
   display: flex;
   justify-content: flex-end;
   flex: 0 0 auto;
-  width: ${props => `${props.width * spacing[400]}px`};
+  width: ${props => `${props.width * FIELD_GLYPH_SPACING}px`};
+`;
+
+const FieldBorderAnimated = styled.div<{ height: string; left: string; width: string }>`
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    width: ${props => props.width};
+    height: ${props => props.height};
+    left: ${props => props.left};
+    top: ${FIELD_BORDER_ANIMATED_PADDING / 2}px;
+    ${animatedBlueBorder};
+    padding: ${FIELD_BORDER_ANIMATED_PADDING}px;
+    margin: -${FIELD_BORDER_ANIMATED_PADDING}px;
+  }
+`;
+
+const FieldBorder = styled(FieldBorderAnimated)`
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+`;
+
+const FieldRow = styled.div`
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
 `;
 
 const FieldName = styled.div`
@@ -58,9 +91,19 @@ const IconWrapper = styled(Icon)`
 interface Props extends NodeField {
   accent: string;
   spacing: number;
+  previewGroupLength?: number;
 }
 
-export const Field = ({ name, depth, type, glyphs, accent, spacing, variant }: Props) => {
+export const Field = ({
+  name,
+  depth = 0,
+  type,
+  glyphs = [],
+  accent,
+  spacing = 0,
+  variant,
+  previewGroupLength = 0,
+}: Props) => {
   const { theme } = useDarkMode();
 
   const getTextColor = () => {
@@ -89,18 +132,34 @@ export const Field = ({ name, depth, type, glyphs, accent, spacing, variant }: P
     }
   };
 
-  return (
-    <FieldWrapper color={getTextColor()}>
-      <InnerFieldWrapper width={spacing}>
-        {glyphs?.map(glyph => (
-          <IconWrapper key={glyph} size={11} color={getIconColor(glyph)} glyph={GlyphToIcon[glyph]} />
-        ))}
-      </InnerFieldWrapper>
+  const content = (
+    <>
       <FieldName>
-        <FieldDepth depth={depth || 0} />
+        <FieldDepth depth={depth} />
         <InnerFieldName>{name}</InnerFieldName>
       </FieldName>
       <FieldType color={getSecondaryTextColor()}>{type}</FieldType>
+    </>
+  );
+
+  return (
+    <FieldWrapper color={getTextColor()}>
+      <InnerFieldWrapper width={spacing}>
+        {glyphs.map(glyph => (
+          <IconWrapper key={glyph} size={11} color={getIconColor(glyph)} glyph={GlyphToIcon[glyph]} />
+        ))}
+      </InnerFieldWrapper>
+      {previewGroupLength ? (
+        <FieldBorder
+          height={`${previewGroupLength * DEFAULT_FIELD_HEIGHT - FIELD_BORDER_ANIMATED_PADDING / 2}px`}
+          left={`${depth * DEFAULT_DEPTH_SPACING - glyphs.length * FIELD_GLYPH_SPACING}px`}
+          width={`calc(100% + ${glyphs.length * FIELD_GLYPH_SPACING - depth * FIELD_BORDER_ANIMATED_PADDING * 2}px)`}
+        >
+          {content}
+        </FieldBorder>
+      ) : (
+        <FieldRow>{content}</FieldRow>
+      )}
     </FieldWrapper>
   );
 };

--- a/src/components/node/node-border.tsx
+++ b/src/components/node/node-border.tsx
@@ -1,38 +1,24 @@
 import { PropsWithChildren } from 'react';
 import styled from '@emotion/styled';
 import { palette } from '@leafygreen-ui/palette';
-import { css, keyframes } from '@emotion/react';
+import { css } from '@emotion/react';
 import { spacing } from '@leafygreen-ui/tokens';
 
 import { NodeBorderVariant } from '@/types';
 import { DEFAULT_NODE_WIDTH } from '@/utilities/constants';
-
-export const rotateAnimation = keyframes({
-  '0%': {
-    backgroundPosition: 'left top, right bottom, left bottom, right top',
-  },
-  '100%': {
-    backgroundPosition: 'left 15px top, right 15px bottom, left bottom 15px, right top 15px',
-  },
-});
+import { animatedBlueBorder } from '@/styles/styles';
 
 const borderProperties = css`
   border-radius: ${spacing[200]}px;
   width: ${DEFAULT_NODE_WIDTH + spacing[50]}px;
 `;
 
-export const AnimatedBorder = styled.div`
-  background: linear-gradient(90deg, ${palette.blue.base} 50%, transparent 50%),
-    linear-gradient(90deg, ${palette.blue.base} 50%, transparent 50%),
-    linear-gradient(0deg, ${palette.blue.base} 50%, transparent 50%),
-    linear-gradient(0deg, ${palette.blue.base} 50%, transparent 50%);
-  background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
-  background-position: left top, right bottom, left bottom, right top;
-  background-size: 15px 2px, 15px 2px, 2px 15px, 2px 15px;
+export const AnimatedBorder = styled.div<{ height?: string }>`
+  height: ${props => (props.height ? props.height : '100%')};
   padding: ${spacing[100]}px;
   margin: -${spacing[100]}px;
-  animation: ${rotateAnimation} 1s linear infinite;
-  ${borderProperties}
+  ${animatedBlueBorder};
+  ${borderProperties};
 `;
 
 const BasicBorder = styled.div<{ outlineBorderColor?: string }>`

--- a/src/components/node/node.stories.tsx
+++ b/src/components/node/node.stories.tsx
@@ -207,6 +207,220 @@ export const NodeWithPrimaryField: Story = {
   },
 };
 
+export const NodeWithPreviewFields: Story = {
+  args: {
+    ...INTERNAL_NODE,
+    type: 'connectable',
+    data: {
+      title: 'orders',
+      fields: [
+        {
+          name: 'customerId',
+          type: 'string',
+        },
+        {
+          name: 'companyName',
+          type: 'string',
+          variant: 'preview',
+        },
+        {
+          name: 'phoneNumber',
+          type: 'number',
+          variant: 'preview',
+        },
+        {
+          name: 'address',
+          type: 'string',
+          variant: 'preview',
+        },
+      ],
+    },
+  },
+};
+
+export const NodeWithPreviewGlyphs: Story = {
+  args: {
+    ...INTERNAL_NODE,
+    type: 'connectable',
+    data: {
+      title: 'orders',
+      fields: [
+        {
+          name: 'customerId',
+          type: 'string',
+          variant: 'preview',
+          glyphs: ['key', 'link'],
+        },
+        {
+          name: 'companyName',
+          type: 'string',
+          variant: 'preview',
+        },
+      ],
+    },
+  },
+};
+
+export const NodeWithSomePreviewGlyphs: Story = {
+  args: {
+    ...INTERNAL_NODE,
+    type: 'connectable',
+    data: {
+      title: 'orders',
+      fields: [
+        {
+          name: 'customerId',
+          type: 'string',
+          glyphs: ['key', 'link'],
+        },
+        {
+          name: 'companyName',
+          type: 'string',
+          variant: 'preview',
+        },
+        {
+          name: 'address',
+          type: 'string',
+          variant: 'preview',
+        },
+        {
+          name: 'fullName',
+          type: 'string',
+          variant: 'preview',
+        },
+      ],
+    },
+  },
+};
+
+export const NodeWithNestedPreviewFields: Story = {
+  args: {
+    ...INTERNAL_NODE,
+    type: 'connectable',
+    data: {
+      title: 'orders',
+      fields: [
+        {
+          name: 'orderId',
+          type: 'string',
+          glyphs: ['key'],
+        },
+        {
+          name: 'customer',
+          type: '{}',
+          variant: 'preview',
+        },
+        {
+          name: 'customerId',
+          type: 'string',
+          depth: 1,
+          variant: 'preview',
+        },
+        {
+          name: 'addresses',
+          type: '[]',
+          depth: 1,
+          variant: 'preview',
+        },
+        {
+          name: 'streetName',
+          type: 'string',
+          depth: 2,
+          variant: 'preview',
+        },
+      ],
+    },
+  },
+};
+
+export const NodeWithDeeplyNestedPreviewFields: Story = {
+  args: {
+    ...INTERNAL_NODE,
+    type: 'connectable',
+    data: {
+      title: 'orders',
+      fields: [
+        {
+          name: 'orderId',
+          type: 'string',
+          glyphs: ['key'],
+        },
+        {
+          name: 'customer',
+          type: '{}',
+        },
+        {
+          name: 'customerId',
+          type: 'string',
+          depth: 1,
+        },
+        {
+          name: 'addresses',
+          type: '[]',
+          depth: 1,
+          variant: 'preview',
+        },
+        {
+          name: 'streetName',
+          type: 'string',
+          depth: 2,
+          variant: 'preview',
+        },
+        {
+          name: 'postcode',
+          type: 'number',
+          depth: 2,
+          variant: 'preview',
+        },
+        {
+          name: 'country',
+          type: 'string',
+          depth: 2,
+          variant: 'preview',
+        },
+      ],
+    },
+  },
+};
+
+export const NodeWithDeeplyNestedPreviewFieldsEverywhere: Story = {
+  args: {
+    ...INTERNAL_NODE,
+    type: 'connectable',
+    data: {
+      title: 'orders',
+      fields: [
+        {
+          name: 'orderId',
+          type: 'string',
+          glyphs: ['key'],
+          variant: 'preview',
+        },
+        {
+          name: 'customer',
+          type: '{}',
+        },
+        {
+          name: 'customerId',
+          type: 'string',
+          depth: 1,
+        },
+        {
+          name: 'addresses',
+          type: '[]',
+          depth: 1,
+        },
+        {
+          name: 'streetName',
+          type: 'string',
+          depth: 2,
+          variant: 'preview',
+        },
+      ],
+    },
+  },
+};
+
 export const SelectedBorder: Story = {
   args: { ...INTERNAL_NODE, data: { ...INTERNAL_NODE.data, borderVariant: 'selected' } },
 };

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -1,7 +1,30 @@
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
+import { palette } from '@leafygreen-ui/palette';
+import { spacing } from '@leafygreen-ui/tokens';
 
 export const ellipsisTruncation = css`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+`;
+
+const rotateAnimation = keyframes({
+  '0%': {
+    backgroundPosition: 'left top, right bottom, left bottom, right top',
+  },
+  '100%': {
+    backgroundPosition: 'left 15px top, right 15px bottom, left bottom 15px, right top 15px',
+  },
+});
+
+export const animatedBlueBorder = css`
+  background: linear-gradient(90deg, ${palette.blue.base} 50%, transparent 50%),
+    linear-gradient(90deg, ${palette.blue.base} 50%, transparent 50%),
+    linear-gradient(0deg, ${palette.blue.base} 50%, transparent 50%),
+    linear-gradient(0deg, ${palette.blue.base} 50%, transparent 50%);
+  background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
+  background-position: left top, right bottom, left bottom, right top;
+  background-size: 15px 2px, 15px 2px, 2px 15px, 2px 15px;
+  animation: ${rotateAnimation} 1s linear infinite;
+  border-radius: ${spacing[200]}px;
 `;

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -4,3 +4,4 @@ export const DEFAULT_NODE_SPACING = 100;
 export const DEFAULT_NODE_STAR_SPACING = 50;
 export const DEFAULT_NODE_HEADER_HEIGHT = 28;
 export const DEFAULT_FIELD_HEIGHT = 18;
+export const DEFAULT_DEPTH_SPACING = 8;

--- a/src/utilities/get-preview-group-lengths.test.ts
+++ b/src/utilities/get-preview-group-lengths.test.ts
@@ -1,0 +1,28 @@
+import { getPreviewGroupLengths } from '@/utilities/get-preview-group-lengths';
+
+describe('get-preview-group-lengths', () => {
+  it('With empty list', () => {
+    const result = getPreviewGroupLengths([]);
+    expect(result).toEqual({});
+  });
+  it('With single field with preview variant', () => {
+    const result = getPreviewGroupLengths([{ variant: 'preview', name: 'orderId' }]);
+    expect(result).toEqual({ orderId: 1 });
+  });
+  it('With all fields with preview variant', () => {
+    const result = getPreviewGroupLengths([
+      { variant: 'preview', name: 'orderId' },
+      { variant: 'preview', name: 'shippingAddress' },
+      { variant: 'preview', name: 'transactionId' },
+    ]);
+    expect(result).toEqual({ orderId: 3 });
+  });
+  it('With some fields with preview variant', () => {
+    const result = getPreviewGroupLengths([
+      { variant: 'preview', name: 'orderId' },
+      { name: 'shippingAddress' },
+      { variant: 'preview', name: 'transactionId' },
+    ]);
+    expect(result).toEqual({ orderId: 1, transactionId: 1 });
+  });
+});

--- a/src/utilities/get-preview-group-lengths.ts
+++ b/src/utilities/get-preview-group-lengths.ts
@@ -1,0 +1,29 @@
+import { NodeField } from '@/types';
+
+/**
+ * Computes the lengths of consecutive groups of fields with the variant 'preview'.
+ * Each group is keyed by the `name` of its first field.
+ */
+export const getPreviewGroupLengths = (fields: Array<NodeField>) => {
+  const borderLength: Record<string, number> = {};
+  let currentGroup: string[] = [];
+
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i];
+
+    if (field.variant === 'preview') {
+      currentGroup.push(field.name);
+    } else {
+      if (currentGroup.length > 0) {
+        borderLength[currentGroup[0]] = currentGroup.length;
+        currentGroup = [];
+      }
+    }
+  }
+
+  if (currentGroup.length > 0) {
+    borderLength[currentGroup[0]] = currentGroup.length;
+  }
+
+  return borderLength;
+};


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: MIG-6579
- :art: [Figma](https://www.figma.com/files/)

## Description

1. Add preview state to the fields
2. See the [equivalent RM code](https://github.com/mongodb-ets/migrator/blob/49eb9be7e0a44a902dbd56a7a393cfe8e7042216/frontend/src/shared/components/diagram/preview-border-util.ts)

## Notes for Reviewers

1. Run `yarn storybook`
3. Click through all the stories

## :camera_flash: Screenshots/Screencasts

https://github.com/user-attachments/assets/045f0031-36be-47d0-a50c-8fe57add3f18

