### PR TITLE
bugfix/MIG-6656 Fix light mode and dark mode icon colour

### DIFF
--- a/src/styles/theme-dark.ts
+++ b/src/styles/theme-dark.ts
@@ -24,7 +24,7 @@ export const DARK_THEME: Theme = {
     backgroundHover: palette.gray.dark3,
     color: palette.gray.light2,
     border: palette.gray.dark1,
-    icon: palette.gray.dark1,
+    icon: palette.gray.light1,
     relationalAccent: purple30,
     mongoDBAccent: palette.green.base,
     disabledAccent: palette.gray.base,

--- a/src/styles/theme-light.ts
+++ b/src/styles/theme-light.ts
@@ -22,7 +22,7 @@ export const LIGHT_THEME: Theme = {
     backgroundHover: palette.gray.light3,
     color: palette.black,
     border: palette.gray.base,
-    icon: palette.gray.light1,
+    icon: palette.gray.dark1,
     relationalAccent: palette.purple.base,
     mongoDBAccent: palette.green.dark1,
     disabledAccent: palette.gray.light1,


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: MIG-6656
- :art: [Figma](https://www.figma.com/files/)

## Description

* Accidentally swapped the two values, making them the correct colour now