### PR TITLE
feature/MIG-6689 Fix selectable prop and prevent delete

### DIFF
--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -66,6 +66,7 @@ export const Canvas = ({ title, nodes: externalNodes, edges: externalEdges, onCo
     <ReactFlowWrapper>
       <ReactFlow
         id={id}
+        deleteKeyCode={null}
         title={title}
         proOptions={PRO_OPTIONS}
         maxZoom={MAX_ZOOM}

--- a/src/components/canvas/use-canvas.test.tsx
+++ b/src/components/canvas/use-canvas.test.tsx
@@ -17,7 +17,6 @@ describe('use-canvas', () => {
         },
         draggable: false,
         connectable: false,
-        selectable: true,
         measured: {
           height: 36,
           width: 244,
@@ -44,7 +43,6 @@ describe('use-canvas', () => {
         },
         draggable: true,
         connectable: false,
-        selectable: true,
         data: {
           fields: [
             { name: 'employeeId', type: 'objectId', glyphs: ['key'] },
@@ -69,6 +67,7 @@ describe('use-canvas', () => {
         },
         draggable: false,
         connectable: true,
+        selectable: false,
         measured: {
           height: 36,
           width: 244,

--- a/src/components/canvas/use-canvas.tsx
+++ b/src/components/canvas/use-canvas.tsx
@@ -11,7 +11,7 @@ export const useCanvas = (externalNodes: ExternalNode[], externalEdges: EdgeProp
         return {
           ...rest,
           draggable: !disabled && !connectable,
-          selectable: !connectable || selectable,
+          selectable: !connectable && selectable,
           connectable: connectable ?? false,
           data: {
             title,


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: MIG-6689
- :art: [Figma](https://www.figma.com/files/)

## Description

1. Fix the "selectable" prop - Ensure that when selectable is `false` that it is truly false, the `connectable` prop was overriding it using the `||` operator. 
2. Set the delete key to `null` - Ensures that diagram nodes cannot be deleted accidentally on key press.