### PR TITLE
bugfix/MIG-6765 Don't infer draggable or selectable prop

### DIFF
--- a/src/components/canvas/use-canvas.test.tsx
+++ b/src/components/canvas/use-canvas.test.tsx
@@ -15,7 +15,6 @@ describe('use-canvas', () => {
           x: 100,
           y: 100,
         },
-        draggable: false,
         connectable: false,
         measured: {
           height: 36,
@@ -41,7 +40,6 @@ describe('use-canvas', () => {
           height: 72,
           width: 244,
         },
-        draggable: true,
         connectable: false,
         data: {
           fields: [
@@ -65,9 +63,7 @@ describe('use-canvas', () => {
           x: 100,
           y: 100,
         },
-        draggable: false,
         connectable: true,
-        selectable: false,
         measured: {
           height: 36,
           width: 244,
@@ -92,7 +88,6 @@ describe('use-canvas', () => {
           x: 100,
           y: 100,
         },
-        draggable: true,
         selectable: true,
         connectable: false,
         measured: {

--- a/src/components/canvas/use-canvas.tsx
+++ b/src/components/canvas/use-canvas.tsx
@@ -7,11 +7,9 @@ export const useCanvas = (externalNodes: ExternalNode[], externalEdges: EdgeProp
   const initialNodes: InternalNode[] = useMemo(
     () =>
       externalNodes.map(node => {
-        const { title, fields, borderVariant, disabled, connectable, selectable, ...rest } = node;
+        const { title, fields, borderVariant, disabled, connectable, ...rest } = node;
         return {
           ...rest,
-          draggable: !disabled && !connectable,
-          selectable: !connectable && selectable,
           connectable: connectable ?? false,
           data: {
             title,


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: MIG-6765
- :art: [Figma](https://www.figma.com/files/)

## Description

* The `connectable` prop setting the `draggable` and `selectable` to false was interfering with the pointer event behaviour when hovering over a synthetic foreign key in Relational Migrator 
* It is a tad strange that we infer this prop for them, so this change allow the consumer of the diagram to set their own `draggable` and `selectable` prop instead