### PR TITLE
bugfix/MIG-6833 Fix glyph alignment

### DIFF
--- a/src/components/field/field-list.tsx
+++ b/src/components/field/field-list.tsx
@@ -22,19 +22,16 @@ export const FieldList = ({ fields, nodeType, isHovering }: Props) => {
   const previewGroupLength = getPreviewGroupLengths(fields);
   return (
     <NodeFieldWrapper>
-      {fields.map(({ name, type: fieldType, hoverVariant, depth, glyphs, variant }, i) => (
+      {fields.map(({ name, type: fieldType, ...rest }, i) => (
         <Field
           key={i}
           name={name}
           nodeType={nodeType}
-          hoverVariant={hoverVariant}
-          depth={depth}
           isHovering={isHovering}
           previewGroupLength={previewGroupLength[name]}
-          glyphs={glyphs}
           type={fieldType}
           spacing={spacing}
-          variant={variant}
+          {...rest}
         />
       ))}
     </NodeFieldWrapper>

--- a/src/components/field/field.tsx
+++ b/src/components/field/field.tsx
@@ -28,7 +28,7 @@ const FieldWrapper = styled.div<{ color: string }>`
 
 const InnerFieldWrapper = styled.div<{ width: number }>`
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   flex: 0 0 auto;
   width: ${props => `${props.width * FIELD_GLYPH_SPACING}px`};
 `;
@@ -85,6 +85,7 @@ const FieldType = styled.div`
 
 const IconWrapper = styled(Icon)`
   padding-right: ${spacing[100]}px;
+  flex-shrink: 0;
 `;
 
 interface Props extends NodeField {
@@ -102,6 +103,7 @@ export const Field = ({
   type,
   nodeType,
   glyphs = [],
+  glyphSize = LGSpacing[300],
   spacing = 0,
   variant,
   previewGroupLength = 0,
@@ -183,7 +185,7 @@ export const Field = ({
     <FieldWrapper color={getTextColor()}>
       <InnerFieldWrapper width={spacing}>
         {glyphs.map(glyph => (
-          <IconWrapper key={glyph} color={getIconColor(glyph)} glyph={GlyphToIcon[glyph]} />
+          <IconWrapper key={glyph} color={getIconColor(glyph)} glyph={GlyphToIcon[glyph]} size={glyphSize} />
         ))}
       </InnerFieldWrapper>
       {previewGroupLength ? (

--- a/src/components/node/node.stories.tsx
+++ b/src/components/node/node.stories.tsx
@@ -93,6 +93,7 @@ export const FieldsWithGlyphs: Story = {
         {
           name: 'addressId',
           type: 'string',
+          glyphs: ['link'],
         },
       ],
     },

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -27,6 +27,7 @@ export interface NodeField {
   type?: string;
   depth?: number;
   glyphs?: Array<NodeGlyph>;
+  glyphSize?: number;
   variant?: NodeFieldVariant;
   hoverVariant?: NodeFieldHoverVariant;
 }


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: MIG-6833
- :art: [Figma](https://www.figma.com/files/)

## Description

1. Changes the glyph alignment to be `flex-start` and not `flex-end` 
2. Allow consumers to specify their own glyph size, if necessary 

## :camera_flash: Screenshots/Screencasts

<img width="362" alt="Screenshot 2025-05-27 at 9 53 56 AM" src="https://github.com/user-attachments/assets/bb4cf93f-292e-4cd3-9766-270f48760493" />
