### PR TITLE
feature/COMPASS-9447 expose export helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,10 @@ export * from '@/components/diagram';
 export * from '@/utilities/apply-layout';
 export * from '@/utilities/add-nodes-within-bounds';
 export * from '@/types';
-export { ReactFlowProvider as DiagramProvider, useReactFlow as useDiagram, useOnSelectionChange } from '@xyflow/react';
+export {
+  ReactFlowProvider as DiagramProvider,
+  useReactFlow as useDiagram,
+  useOnSelectionChange,
+  getNodesBounds,
+  getViewportForBounds,
+} from '@xyflow/react';

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -177,4 +177,11 @@ export interface DiagramProps {
    * Minimum allowed zoom level.
    */
   minZoom?: number;
+
+  /**
+   * Whether to only render elements that are currently visible in the viewport.
+   * This can improve performance for large diagrams.
+   * @defaults true
+   */
+  onlyRenderVisibleElements?: boolean;
 }


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: [COMPASS-9447](https://jira.mongodb.org/browse/COMPASS-9447)

## Description

In order to export the diagram to an image, we are exporting `@xyflow/react` helpers that help in estimating the bounds and viewport for nodes in the diagram.  

As we are using virtualization for the diagram by default, I am also exposing `onlyRenderVisibleElements` prop on `Diagram` which we will be using on Compass side for exporting the diagram.

