### PR TITLE
chore/COMPASS-9457 add CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '30 14 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - actions
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config: |
+            paths-ignore:
+              - 'test-setup.ts'
+              - 'src/**/*.test.ts'
+              - 'src/**/*.spec.ts'
+              - 'src/**/*.test.tsx'
+              - 'src/**/*.spec.tsx'
+              - 'src/**/*.stories.tsx'
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: [COMPASS-9457](http://jira.mongodb.org/browse/COMPASS-9457)

## Description

In this PR, we added CodeQL Github Actions workflow. For this repository, CodeQL is already enabled and in order to have static analysis results, we need this. This came into light when adding this package within Compass and its CI fails because this package is a first-party dependency and we need to have CodeQL results.