### PR TITLE
feature/COMPASS-9432 Use measured heights or calculate

### DIFF
--- a/src/utilities/apply-layout.test.ts
+++ b/src/utilities/apply-layout.test.ts
@@ -1,5 +1,5 @@
 import { applyLayout } from '@/utilities/apply-layout';
-import { EdgeProps, NodeProps } from '@/types';
+import { BaseNode, EdgeProps, NodeProps } from '@/types';
 
 describe('apply-layout', () => {
   const nodes: NodeProps[] = [
@@ -50,37 +50,125 @@ describe('apply-layout', () => {
       edges: [],
     });
   });
-  it('With nodes', async () => {
+  it('With nodes (not measured, 0 fields)', async () => {
     const result = await applyLayout<NodeProps, EdgeProps>(nodes, [], 'TOP_BOTTOM');
     expect(result.nodes).toEqual([
       expect.objectContaining({
-        title: 'orders',
-        fields: [],
-        type: 'collection',
-        id: '1',
+        ...nodes[0],
         position: {
           x: 12,
           y: 12,
         },
       }),
       expect.objectContaining({
-        title: 'customers',
-        fields: [],
-        type: 'collection',
-        id: '2',
+        ...nodes[1],
         position: {
           x: 12,
-          y: 32,
+          y: 76, // 12 + 44 (0 fields height) + 2*10 (padding)
         },
       }),
       expect.objectContaining({
-        title: 'products',
-        fields: [],
-        type: 'collection',
-        id: '3',
+        ...nodes[2],
         position: {
           x: 12,
-          y: 52,
+          y: 140, // 76 + 44 (0 fields height) + 2*10 (padding)
+        },
+      }),
+    ]);
+  });
+  it('With nodes (not measured, 1 field)', async () => {
+    const nodesWithOneField = nodes.map((node) => ({
+      ...node,
+      fields: [{ name: 'field1', type: 'string' }],
+    }));
+    const result = await applyLayout<NodeProps, EdgeProps>(nodesWithOneField, [], 'TOP_BOTTOM');
+    expect(result.nodes).toEqual([
+      expect.objectContaining({
+        ...nodesWithOneField[0],
+        position: {
+          x: 12,
+          y: 12,
+        },
+      }),
+      expect.objectContaining({
+        ...nodesWithOneField[1],
+        position: {
+          x: 12,
+          y: 94, // 12 + 62 (1 field height) + 2*10 (padding)
+        },
+      }),
+      expect.objectContaining({
+        ...nodesWithOneField[2],
+        position: {
+          x: 12,
+          y: 176, // 94 + 62 (1 field height) + 2*10 (padding)
+        },
+      }),
+    ]);
+  });
+  it('With nodes (not measured, undefined fields)', async () => {
+    const baseNodes = nodes.map((node) => ({
+      ...node,
+      fields: undefined,
+    }));
+    const result = await applyLayout<BaseNode, EdgeProps>(baseNodes, [], 'TOP_BOTTOM');
+    expect(result.nodes).toEqual([
+      expect.objectContaining({
+        ...baseNodes[0],
+        position: {
+          x: 12,
+          y: 12,
+        },
+      }),
+      expect.objectContaining({
+        ...baseNodes[1],
+        position: {
+          x: 12,
+          y: 94, // 12 + 62 (default height) + 2*10 (padding)
+        },
+      }),
+      expect.objectContaining({
+        ...baseNodes[2],
+        position: {
+          x: 12,
+          y: 176, // 94 + 62 (default height) + 2*10 (padding)
+        },
+      }),
+    ]);
+  });
+  it('With nodes (measured)', async () => {
+    const measuredNodes = nodes.map((node) => ({
+      ...node,
+      measured: {
+        width: 100,
+        height: 50,
+      },
+    }));
+    const result = await applyLayout<NodeProps, EdgeProps>(
+      measuredNodes,
+      [],
+      'TOP_BOTTOM'
+    );
+    expect(result.nodes).toEqual([
+      expect.objectContaining({
+        ...measuredNodes[0],
+        position: {
+          x: 12,
+          y: 12,
+        },
+      }),
+      expect.objectContaining({
+        ...measuredNodes[1],
+        position: {
+          x: 12,
+          y: 82, // 12 + 50 (measured node height) + 2*10 (padding)
+        },
+      }),
+      expect.objectContaining({
+        ...measuredNodes[2],
+        position: {
+          x: 12,
+          y: 152, // 82 + 50 (measured node height) + 2*10 (padding)
         },
       }),
     ]);
@@ -104,7 +192,7 @@ describe('apply-layout', () => {
         id: '1',
         position: {
           x: 12,
-          y: 12,
+          y: 76,
         },
       }),
       expect.objectContaining({
@@ -114,7 +202,7 @@ describe('apply-layout', () => {
         id: '2',
         position: {
           x: 12,
-          y: 132,
+          y: 12,
         },
       }),
       expect.objectContaining({
@@ -124,7 +212,7 @@ describe('apply-layout', () => {
         id: '3',
         position: {
           x: 12,
-          y: 112,
+          y: 220,
         },
       }),
     ]);

--- a/src/utilities/apply-layout.ts
+++ b/src/utilities/apply-layout.ts
@@ -35,6 +35,13 @@ const getLayoutOptions = (direction: LayoutDirection) => {
   }
 };
 
+const getNodeHeight = <N extends BaseNode>(node: N) => {
+  if (!('fields' in node) || !Array.isArray(node.fields))
+    return 28 + 16 + 18; // Default height
+  const fieldCount = node.fields.length;
+  return 28 + 16 + fieldCount * 18;
+};
+
 /**
  * Applies a layout to a graph of nodes and edges using the ELK layout engine.
  *
@@ -51,6 +58,12 @@ export const applyLayout = <N extends BaseNode, E extends BaseEdge>(
   edges: E[],
   direction: LayoutDirection = 'TOP_BOTTOM',
 ): Promise<ApplyLayout<N, E>> => {
+  const transformedNodes = nodes.map<N>(node => ({
+    ...node,
+    height: node.measured?.height ?? getNodeHeight(node),
+    width: node.measured?.width ?? 244,
+  }));
+
   const transformedEdges = edges.map<ElkExtendedEdge>(edge => ({
     ...edge,
     id: edge.id,
@@ -66,7 +79,7 @@ export const applyLayout = <N extends BaseNode, E extends BaseEdge>(
   return elk
     .layout({
       id: 'root',
-      children: nodes,
+      children: transformedNodes,
       layoutOptions: getLayoutOptions(direction),
       edges: transformedEdges,
     })

--- a/src/utilities/apply-layout.ts
+++ b/src/utilities/apply-layout.ts
@@ -1,7 +1,7 @@
 import { ElkExtendedEdge } from 'elkjs';
 import ELK from 'elkjs/lib/elk.bundled';
 
-import { DEFAULT_NODE_SPACING, DEFAULT_NODE_STAR_SPACING } from '@/utilities/constants';
+import { DEFAULT_FIELD_HEIGHT, DEFAULT_FIELD_PADDING, DEFAULT_NODE_HEADER_HEIGHT, DEFAULT_NODE_SPACING, DEFAULT_NODE_STAR_SPACING, DEFAULT_NODE_WIDTH } from '@/utilities/constants';
 import { ApplyLayout, BaseEdge, BaseNode, LayoutDirection } from '@/types/layout';
 
 const TOP_BOTTOM = {
@@ -36,10 +36,8 @@ const getLayoutOptions = (direction: LayoutDirection) => {
 };
 
 const getNodeHeight = <N extends BaseNode>(node: N) => {
-  if (!('fields' in node) || !Array.isArray(node.fields))
-    return 28 + 16 + 18; // Default height
-  const fieldCount = node.fields.length;
-  return 28 + 16 + fieldCount * 18;
+  const fieldCount = (!('fields' in node) || !Array.isArray(node.fields)) ? 1 : node.fields.length;
+  return DEFAULT_NODE_HEADER_HEIGHT + DEFAULT_FIELD_PADDING * 2 + fieldCount * DEFAULT_FIELD_HEIGHT;
 };
 
 /**
@@ -60,8 +58,12 @@ export const applyLayout = <N extends BaseNode, E extends BaseEdge>(
 ): Promise<ApplyLayout<N, E>> => {
   const transformedNodes = nodes.map<N>(node => ({
     ...node,
-    height: node.measured?.height ?? getNodeHeight(node),
-    width: node.measured?.width ?? 244,
+    height: ('height' in node && typeof node.height === 'number') 
+      ? node.height
+      : node.measured?.height ?? getNodeHeight(node),
+    width: ('width' in node && typeof node.width === 'number')
+      ? node.width
+      : node.measured?.width ?? DEFAULT_NODE_WIDTH,
   }));
 
   const transformedEdges = edges.map<ElkExtendedEdge>(edge => ({


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: COMPASS-9432

## Description

We use `node.measured.width|height` (see [interface BaseNode](https://github.com/mongodb-js/diagramming/blob/38508af112cc74922f3c4426a714f590845c72b7/src/types/layout.ts#L25)). `elkjs` library uses top level `node.width|height`. In `applyLayout`, we've been ignoring the `measured` values and expecting the top level ones, creating an unexpected inconsistency.
This is already used in the migrator, so I'm keeping the top level dimensions to avoid a breaking change.

The other change is, if the measured values will not be provided, the function will apply defaults. I see this as the preferred way, as it keeps the separation of knowledge (the client doesn't need to know about default node styles).

## Notes for Reviewers

<!-- Any additional notes that are useful for reviewers e.g. repro steps, specific code changes to look into etc. -->

## :camera_flash: Screenshots/Screencasts

<!-- A picture speaks a thousand words, an animated GIF millions more. Help reviewers to understand your proposed changes by providing 	screenshot/screencast of your changes (if applicable). A before and after of the change provides additional context on what's changed. -->

### Before

### After