### PR TITLE
feature/COMPASS-9433 Allow react node in node type prop

### DIFF
--- a/src/components/node/node.stories.tsx
+++ b/src/components/node/node.stories.tsx
@@ -221,6 +221,27 @@ export const DisabledWithHoverVariant: Story = {
   },
 };
 
+export const NodeWithCustomTypeField: Story = {
+  args: {
+    ...INTERNAL_NODE,
+    data: {
+      title: 'orders',
+      fields: [
+        {
+          name: 'customerId',
+          type: (
+            <span>
+              <strong>custom type display</strong>
+            </span>
+          ),
+          variant: 'default',
+          glyphs: ['key'],
+        },
+      ],
+    },
+  },
+};
+
 export const NodeWithPrimaryField: Story = {
   args: {
     ...INTERNAL_NODE,

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -138,7 +138,7 @@ export interface NodeField {
   /**
    * The type of the field, for example "objectId".
    */
-  type?: string;
+  type?: string | React.ReactNode;
 
   /**
    * The depth of the field.


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: [COMPASS-9433](https://jira.mongodb.org/browse/COMPASS-9433)
- :art: [Figma](https://www.figma.com/design/w51HGIb2PDdyZqyCOMMypr/-INIT-592--Data-Model-Design-Experience?node-id=69-18480&m=dev)

## Description

Updates the node field type to allow for us to provide react nodes (we want to show tooltips on hover).