### PR TITLE
feature/COMPASS-9629 expose onNodeClick and nodeDragThreshold component props

### DIFF
--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -54,6 +54,7 @@ export const Canvas = ({
   onNodeDrag,
   onNodeDragStop,
   onEdgeClick,
+  onNodeClick,
   onSelectionDragStop,
   onSelectionContextMenu,
   onSelectionChange,
@@ -110,6 +111,13 @@ export const Canvas = ({
     [onEdgeClick],
   );
 
+  const _onNodeClick = useCallback(
+    (event: MouseEvent, node: InternalNode) => {
+      onNodeClick?.(event, convertToExternalNode(node));
+    },
+    [onNodeClick],
+  );
+
   const _onSelectionContextMenu = useCallback(
     (event: MouseEvent, nodes: InternalNode[]) => {
       onSelectionContextMenu?.(event, convertToExternalNodes(nodes));
@@ -149,6 +157,7 @@ export const Canvas = ({
         onNodeDragStop={_onNodeDragStop}
         onSelectionDragStop={_onSelectionDragStop}
         onEdgeClick={_onEdgeClick}
+        onNodeClick={_onNodeClick}
         onSelectionContextMenu={_onSelectionContextMenu}
         onSelectionChange={_onSelectionChange}
         {...rest}

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -20,6 +20,11 @@ export type OnPaneClickHandler = (event: ReactMouseEvent) => void;
 export type OnEdgeClickHandler = (event: ReactMouseEvent, edge: EdgeProps) => void;
 
 /**
+ * Called when a node is clicked.
+ */
+export type OnNodeClickHandler = (event: ReactMouseEvent, edge: NodeProps) => void;
+
+/**
  * Called when a node is right-clicked.
  */
 export type OnNodeContextMenuHandler = (event: ReactMouseEvent, node: NodeProps) => void;
@@ -104,6 +109,11 @@ export interface DiagramProps {
   onEdgeClick?: OnEdgeClickHandler;
 
   /**
+   * Callback when the user clicks on a node.
+   */
+  onNodeClick?: OnNodeClickHandler;
+
+  /**
    * Callback when the user right-clicks on a node.
    */
   onNodeContextMenu?: OnNodeContextMenuHandler;
@@ -181,7 +191,15 @@ export interface DiagramProps {
   /**
    * Whether to only render elements that are currently visible in the viewport.
    * This can improve performance for large diagrams.
-   * @defaults true
+   * @default true
    */
   onlyRenderVisibleElements?: boolean;
+
+  /**
+   * With a threshold greater than zero you can delay node drag events. If
+   * threshold equals 1, you need to drag the node 1 pixel before a drag event
+   * is fired. 1 is the default value, so that clicks don’t trigger drag events.
+   * @default 1
+   */
+  nodeDragThreshold?: number;
 }


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: [COMPASS-9629](https://jira.mongodb.org/browse/COMPASS-9629)

## Description

Some interaction with diagram in compass requires us to react to the node click event to the component, we're currently doing this by just ignoring typescript errors as the props are being passed through, but would like to remove the `ts-expect-error` statements from the code. Also when adding node click, we realised that the default `nodeDragThreshold` is too low, so clicks are not registering too often, so this is another prop that is getting exposed in this patch

## Notes for Reviewers

N/A

## :camera_flash: Screenshots/Screencasts

N/A

### Before

N/A

### After

N/A