### PR TITLE
fix/COMPASS-9664 fix default height calc

### DIFF
--- a/src/components/edge/floating-edge.test.tsx
+++ b/src/components/edge/floating-edge.test.tsx
@@ -57,7 +57,7 @@ describe('floating-edge', () => {
       expect(path).toHaveAttribute('id', 'orders-to-employees');
       expect(path).toHaveAttribute(
         'd',
-        'M269.5 180L289.5 180L 386.5,180Q 391.5,180 391.5,185L 391.5,295Q 391.5,300 386.5,300L371.5 300',
+        'M267 197.5L267 217.5L 267,240Q 267,245 272,245L 354,245Q 359,245 359,250L359 272.5L359 292.5',
       );
     });
   });

--- a/src/components/edge/self-referencing-edge.test.tsx
+++ b/src/components/edge/self-referencing-edge.test.tsx
@@ -53,7 +53,7 @@ describe('self-referencing-edge', () => {
       renderComponent();
       const path = screen.getByTestId('self-referencing-edge-employees-to-employees');
       expect(path).toHaveAttribute('id', 'employees-to-employees');
-      expect(path).toHaveAttribute('d', 'M422,292.5L422,262.5L584,262.5L584,350.5L551.5,350.5');
+      expect(path).toHaveAttribute('d', 'M422,292.5L422,262.5L584,262.5L584,355.5L551.5,355.5');
     });
   });
 

--- a/src/utilities/apply-layout.test.ts
+++ b/src/utilities/apply-layout.test.ts
@@ -64,14 +64,14 @@ describe('apply-layout', () => {
         ...nodes[1],
         position: {
           x: 12,
-          y: 76, // 12 + 44 (0 fields height) + 2*10 (padding)
+          y: 86, // 12 + 44 (0 fields height) + 2*10 (padding) + 10 (extra padding)
         },
       }),
       expect.objectContaining({
         ...nodes[2],
         position: {
           x: 12,
-          y: 140, // 76 + 44 (0 fields height) + 2*10 (padding)
+          y: 160, // 86 + 44 (0 fields height) + 2*10 (padding) + 10 (extra padding)
         },
       }),
     ]);
@@ -94,14 +94,14 @@ describe('apply-layout', () => {
         ...nodesWithOneField[1],
         position: {
           x: 12,
-          y: 94, // 12 + 62 (1 field height) + 2*10 (padding)
+          y: 104, // 12 + 62 (1 field height) + 2*10 (padding) + 10 (extra padding)
         },
       }),
       expect.objectContaining({
         ...nodesWithOneField[2],
         position: {
           x: 12,
-          y: 176, // 94 + 62 (1 field height) + 2*10 (padding)
+          y: 196, // 104 + 62 (1 field height) + 2*10 (padding) + 10 (extra padding)
         },
       }),
     ]);
@@ -124,14 +124,14 @@ describe('apply-layout', () => {
         ...baseNodes[1],
         position: {
           x: 12,
-          y: 94, // 12 + 62 (default height) + 2*10 (padding)
+          y: 104, // 12 + 62 (default height) + 2*10 (padding) + 10 (extra padding)
         },
       }),
       expect.objectContaining({
         ...baseNodes[2],
         position: {
           x: 12,
-          y: 176, // 94 + 62 (default height) + 2*10 (padding)
+          y: 196, // 104 + 62 (default height) + 2*10 (padding) + 10 (extra padding)
         },
       }),
     ]);
@@ -188,7 +188,7 @@ describe('apply-layout', () => {
         id: '1',
         position: {
           x: 12,
-          y: 76,
+          y: 86,
         },
       }),
       expect.objectContaining({
@@ -208,7 +208,7 @@ describe('apply-layout', () => {
         id: '3',
         position: {
           x: 12,
-          y: 220,
+          y: 240,
         },
       }),
     ]);

--- a/src/utilities/get-edge-params.test.ts
+++ b/src/utilities/get-edge-params.test.ts
@@ -10,12 +10,12 @@ describe('get-edge-params', () => {
         { ...EMPLOYEES_NODE, data: { title: EMPLOYEES_NODE.title, fields: EMPLOYEES_NODE.fields } },
       );
       expect(result).toEqual({
-        sourcePos: 'right',
-        sx: 269.5,
-        sy: 180,
-        targetPos: 'right',
-        tx: 371.5,
-        ty: 300,
+        sourcePos: 'bottom',
+        sx: 267,
+        sy: 197.5,
+        targetPos: 'top',
+        tx: 359,
+        ty: 292.5,
       });
     });
   });

--- a/src/utilities/get-edge-params.ts
+++ b/src/utilities/get-edge-params.ts
@@ -54,13 +54,13 @@ const getEdgePosition = (node: InternalNode, intersectionPoint: XYPosition) => {
   if (px <= nx + 1) {
     return Position.Left;
   }
-  if (px >= nx + (n.measured?.width ?? 0) - 1) {
+  if (px >= nx + (getNodeWidth(n) - 1)) {
     return Position.Right;
   }
   if (py <= ny + 1) {
     return Position.Top;
   }
-  if (py >= n.y + (n.measured?.height ?? 0) - 1) {
+  if (py >= n.y + (getNodeHeight(n) - 1)) {
     return Position.Bottom;
   }
 

--- a/src/utilities/node-dimensions.ts
+++ b/src/utilities/node-dimensions.ts
@@ -1,4 +1,5 @@
-import type { BaseNode } from '@/types';
+import type { BaseNode, NodeProps } from '@/types';
+import { InternalNode } from '@/types/internal';
 
 import {
   DEFAULT_FIELD_HEIGHT,
@@ -7,11 +8,23 @@ import {
   DEFAULT_NODE_WIDTH,
 } from './constants';
 
-export const getNodeHeight = <N extends BaseNode>(node: N) => {
+export const getNodeHeight = <N extends BaseNode | NodeProps | InternalNode>(node: N) => {
   if ('height' in node && typeof node.height === 'number') return node.height;
   if ('measured' in node && node.measured?.height) return node.measured.height;
-  const fieldCount = !('fields' in node) || !Array.isArray(node.fields) ? 1 : node.fields.length;
-  return DEFAULT_NODE_HEADER_HEIGHT + DEFAULT_FIELD_PADDING * 2 + fieldCount * DEFAULT_FIELD_HEIGHT;
+
+  let fieldCount = 1;
+  if ('fields' in node && Array.isArray(node.fields)) {
+    fieldCount = node.fields.length;
+  }
+  if ('data' in node) {
+    let internalNode = node as InternalNode;
+    if (internalNode.data?.fields && Array.isArray(internalNode.data.fields)) {
+      fieldCount = internalNode.data.fields.length;
+    }
+  }
+  const calculatedHeight =
+    DEFAULT_NODE_HEADER_HEIGHT + DEFAULT_FIELD_PADDING * 2 + fieldCount * DEFAULT_FIELD_HEIGHT + 10;
+  return calculatedHeight;
 };
 
 export const getNodeWidth = <N extends BaseNode>(node: N) => {


### PR DESCRIPTION
## Description

I didn't get the height calculation right the first time. Luckily, the non-measured nodes turned out to be the reason for the weird flicker I've been meaning to look into anyway! 
The old flicker was harder to place, but with the not-yet-measured edges rendering in a different position, it was easier to locate the problem. I'm only surprised that the NaN error and the flicker weren't occurring with the same frequency, looks like the NaNs were caught and the edge was simply not rendered in most instances.

Recordings are made with a custom story that refreshes the nodes when the dragging stops. 

PROMINENT FLICKER (the original with the edges simply disappearing was much harder to notice)

https://github.com/user-attachments/assets/869eace8-329d-498b-8395-a71118eb0458

AFTER

https://github.com/user-attachments/assets/c6dda42e-cfa6-4041-9d3b-9a28473b2fab





## Notes for Reviewers

<!-- Any additional notes that are useful for reviewers e.g. repro steps, specific code changes to look into etc. -->

## :camera_flash: Screenshots/Screencasts

<!-- A picture speaks a thousand words, an animated GIF millions more. Help reviewers to understand your proposed changes by providing 	screenshot/screencast of your changes (if applicable). A before and after of the change provides additional context on what's changed. -->

### Before

### After