### PR TITLE
bugfix/MIG-7099 Pin react-flow version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@leafygreen-ui/palette": "^5.0.0",
     "@leafygreen-ui/tokens": "^3.0.0",
     "@leafygreen-ui/typography": "^20.1.4",
-    "@xyflow/react": "^12.5.1",
+    "@xyflow/react": "12.5.1",
     "d3-path": "^3.1.0",
     "elkjs": "^0.10.0",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1322,7 +1322,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:8.39.0"
     "@vitejs/plugin-react": "npm:^4.3.4"
     "@vitest/ui": "npm:3.2.4"
-    "@xyflow/react": "npm:^12.5.1"
+    "@xyflow/react": "npm:12.5.1"
     d3-path: "npm:^3.1.0"
     elkjs: "npm:^0.10.0"
     eslint: "npm:^9.24.0"
@@ -2249,7 +2249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-interpolate@npm:*, @types/d3-interpolate@npm:^3.0.4":
+"@types/d3-interpolate@npm:*":
   version: 3.0.4
   resolution: "@types/d3-interpolate@npm:3.0.4"
   dependencies:
@@ -3152,34 +3152,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xyflow/react@npm:^12.5.1":
-  version: 12.7.0
-  resolution: "@xyflow/react@npm:12.7.0"
+"@xyflow/react@npm:12.5.1":
+  version: 12.5.1
+  resolution: "@xyflow/react@npm:12.5.1"
   dependencies:
-    "@xyflow/system": "npm:0.0.62"
+    "@xyflow/system": "npm:0.0.53"
     classcat: "npm:^5.0.3"
     zustand: "npm:^4.4.0"
   peerDependencies:
     react: ">=17"
     react-dom: ">=17"
-  checksum: 10c0/b302530a53caf0d060f6826110df55c624e71546c24e6189ab4b7c8e8e9613cf41c03d10ed1dc91d77906dd17cc7e94932c1532b8bc240113ac27d7ac270beba
+  checksum: 10c0/969b88445c5ea48492289f0a5411670cd3f8b2d30dabeec876bcdf607cbbc57a243e5c034063b5e3c18dca565c83ebdc1034c4a55d7e65f7c78041d58ab69c28
   languageName: node
   linkType: hard
 
-"@xyflow/system@npm:0.0.62":
-  version: 0.0.62
-  resolution: "@xyflow/system@npm:0.0.62"
+"@xyflow/system@npm:0.0.53":
+  version: 0.0.53
+  resolution: "@xyflow/system@npm:0.0.53"
   dependencies:
     "@types/d3-drag": "npm:^3.0.7"
-    "@types/d3-interpolate": "npm:^3.0.4"
     "@types/d3-selection": "npm:^3.0.10"
     "@types/d3-transition": "npm:^3.0.8"
     "@types/d3-zoom": "npm:^3.0.8"
     d3-drag: "npm:^3.0.0"
-    d3-interpolate: "npm:^3.0.1"
     d3-selection: "npm:^3.0.0"
     d3-zoom: "npm:^3.0.0"
-  checksum: 10c0/5192f96787c3c8c1071d49458206815610a872fddfa8e6fb9bdd8eb6579c57ff2b9a715704cbbe0748ac32aba8cb4103cf9c453c20c3ace0b0c77a37f54f2eea
+  checksum: 10c0/3491a8731eff4302904074b32b6daf17877aaaa1ade158b69f55a021c937498d8b5f37f67618d118a63d30cd8639d8b06bdc9d2cd2afee9a205a4c538cf82cc4
   languageName: node
   linkType: hard
 
@@ -4263,7 +4261,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-interpolate@npm:1 - 3, d3-interpolate@npm:^3.0.1":
+"d3-interpolate@npm:1 - 3":
   version: 3.0.1
   resolution: "d3-interpolate@npm:3.0.1"
   dependencies:


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: MIG-7099
- :art: [Figma](https://www.figma.com/files/)

## Description

* Similar to `react` and `react-dom`, pin the `@xyflow/react` version 
* The upgrade which was [done by dependabot](https://github.com/mongodb-js/diagramming/pull/77) was causing some flickering in RM mini-map (See video)
* For now, just pin the `react-flow` version to what it was before 
* A proper upgrade will be done in the parent story (MIG-7099)

## Screenshots 

https://github.com/user-attachments/assets/742487a9-a8ed-4e2a-82be-a194e4f0003f

