### PR TITLE
feat/COMPASS-9792: Add renderName for custom field name rendering

### DIFF
--- a/src/components/field/field.tsx
+++ b/src/components/field/field.tsx
@@ -145,6 +145,7 @@ export const Field = ({
   selectedGroupHeight = 0,
   previewGroupArea,
   glyphSize = LGSpacing[300],
+  renderName,
   spacing = 0,
   selectable = false,
   selected = false,
@@ -168,6 +169,7 @@ export const Field = ({
   const fieldSelectionProps = useMemo(() => {
     return selectable && fieldProps
       ? {
+          'data-testid': `selectable-field-${nodeId}-${typeof id === 'string' ? id : id.join('.')}`,
           selectable: true,
           onClick: (event: ReactMouseEvent) => fieldProps.onClick(event, { id, nodeId }),
         }
@@ -213,7 +215,7 @@ export const Field = ({
     <>
       <FieldName>
         <FieldDepth depth={depth} />
-        <InnerFieldName>{name}</InnerFieldName>
+        <InnerFieldName>{renderName || name}</InnerFieldName>
       </FieldName>
       <FieldType color={getSecondaryTextColor()}>{type}</FieldType>
     </>

--- a/src/components/node/node.stories.tsx
+++ b/src/components/node/node.stories.tsx
@@ -246,6 +246,33 @@ export const NodeWithCustomTypeField: Story = {
   },
 };
 
+export const NodeWithCustomFieldNameRender: Story = {
+  args: {
+    ...INTERNAL_NODE,
+    data: {
+      title: 'orders',
+      fields: [
+        {
+          name: 'customerId',
+          renderName: (
+            <div style={{ background: 'orange', width: '100%' }}>
+              <input
+                type="text"
+                onSubmit={e => e.preventDefault()}
+                defaultValue="Custom name"
+                style={{ marginLeft: 5, marginRight: 5, width: '90px' }}
+              />
+            </div>
+          ),
+          type: 'string',
+          variant: 'default',
+          glyphs: ['key'],
+        },
+      ],
+    },
+  },
+};
+
 export const NodeWithPrimaryField: Story = {
   args: {
     ...INTERNAL_NODE,

--- a/src/components/node/node.tsx
+++ b/src/components/node/node.tsx
@@ -66,7 +66,8 @@ const NodeHeader = styled.div<{ background?: string }>`
   line-height: 20px;
   font-weight: bold;
   min-height: ${DEFAULT_NODE_HEADER_HEIGHT}px;
-  padding: 0px ${spacing[400]}px 0px ${spacing[200]}px;
+  padding: 0px;
+  padding-left: ${spacing[200]}px;
   background: ${props => props.background};
 `;
 
@@ -79,6 +80,7 @@ const NodeHeaderIcon = styled.div`
 export const NodeHeaderTitle = styled.div`
   overflow-wrap: break-word;
   min-width: 0;
+  margin-right: ${spacing[200]}px;
 `;
 
 const NodeHandle = styled(Handle)<{ ['z-index']?: number }>`

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -144,6 +144,11 @@ export interface NodeField {
   name: string;
 
   /**
+   * Optional custom rendering for the field name. If not provided, `name` will be used.
+   */
+  renderName?: React.ReactNode;
+
+  /**
    * Unique identifier for the field. Passed in field click events.
    * Defaults to `name` when not supplied.
    */


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: COMPASS-9792
- :art: [Figma](https://www.figma.com/design/w51HGIb2PDdyZqyCOMMypr/-PROGRAM-92--Data-Model-Design-Experience?node-id=3919-15477&t=HL4nxoA784rUo2i7-4)

## Description

Adds a `renderName` that, when supplied, replaces the `name` for fields. Includes a drive by adding a `data-testid` for selecting fields as well as removing some padding on the node header so that the actions can be closer to the right of the node header.

## :camera_flash: Screenshots/Screencasts

<img width="307" height="110" alt="Screenshot 2025-09-11 at 9 44 10 AM" src="https://github.com/user-attachments/assets/2e395b5f-ea1a-4b80-94ce-9f7e4fcb044f" />
