### PR TITLE
chore/COMPASS-9767 Add editable interactions stress test story

### DIFF
--- a/src/components/diagram.stories.tsx
+++ b/src/components/diagram.stories.tsx
@@ -6,6 +6,7 @@ import { EMPLOYEES_TO_EMPLOYEES_EDGE, ORDERS_TO_EMPLOYEES_EDGE } from '@/mocks/d
 import { DiagramStressTestDecorator } from '@/mocks/decorators/diagram-stress-test.decorator';
 import { DiagramConnectableDecorator } from '@/mocks/decorators/diagram-connectable.decorator';
 import { DiagramEditableInteractionsDecorator } from '@/mocks/decorators/diagram-editable-interactions.decorator';
+import { DiagramEditableStressTestDecorator } from '@/mocks/decorators/diagram-editable-stress-test.decorator';
 
 const diagram: Meta<typeof Diagram> = {
   title: 'Diagram',
@@ -84,6 +85,16 @@ export const DiagramWithEditInteractions: Story = {
 
 export const DiagramStressTest: Story = {
   decorators: [DiagramStressTestDecorator],
+  args: {
+    title: 'MongoDB Diagram',
+    isDarkMode: true,
+    edges: [],
+    nodes: [],
+  },
+};
+
+export const DiagramEditableStressTest: Story = {
+  decorators: [DiagramEditableStressTestDecorator],
   args: {
     title: 'MongoDB Diagram',
     isDarkMode: true,

--- a/src/mocks/decorators/diagram-editable-stress-test.decorator.tsx
+++ b/src/mocks/decorators/diagram-editable-stress-test.decorator.tsx
@@ -1,0 +1,19 @@
+import { Decorator } from '@storybook/react';
+
+import { DiagramProps } from '@/types';
+import { useEditableNodes } from '@/mocks/decorators/diagram-editable-interactions.decorator';
+import { useStressTestNodesAndEdges } from '@/mocks/decorators/diagram-stress-test.decorator';
+
+export const DiagramEditableStressTestDecorator: Decorator<DiagramProps> = (Story, context) => {
+  const { nodes: initialNodes, edges } = useStressTestNodesAndEdges(100);
+  const editableArgs = useEditableNodes(initialNodes);
+
+  return Story({
+    ...context,
+    args: {
+      ...context.args,
+      ...editableArgs,
+      edges: editableArgs.nodes.length > 0 ? edges : [],
+    },
+  });
+};

--- a/src/mocks/decorators/diagram-stress-test.decorator.tsx
+++ b/src/mocks/decorators/diagram-stress-test.decorator.tsx
@@ -17,45 +17,81 @@ const names = [
   'api_keys',
 ];
 
-export const DiagramStressTestDecorator: Decorator<DiagramProps> = (Story, context) => {
+const types = ['string', 'number', 'boolean', 'date', 'object', 'array'];
+
+let previousWasObject = false;
+let previousDepth = 0;
+function getRandomTypeAndDepth(i: number) {
+  if (i === 0) {
+    previousWasObject = false;
+    previousDepth = 0;
+  }
+  const type = types[Math.floor(Math.random() * types.length)];
+
+  const depth = previousWasObject
+    ? Math.random() > 0.25
+      ? previousDepth + 1
+      : previousDepth
+    : previousDepth > 0 && Math.random() > 0.2
+      ? previousDepth
+      : 0;
+
+  previousWasObject = type === 'object';
+
+  previousDepth = depth || 0;
+
+  return {
+    type,
+    depth,
+  };
+}
+
+const generateNodes = (count: number): NodeProps[] => {
+  return Array.from(Array(count).keys()).map((nodeIndex: number) => ({
+    id: `node_${nodeIndex}`,
+    type: 'table',
+    position: {
+      x: 0,
+      y: 0,
+    },
+    title: names[Math.floor(Math.random() * names.length)],
+    fields: Array.from(Array(1 + (nodeIndex % 9)).keys()).map((fieldIndex: number) => ({
+      name: `${names[Math.floor(Math.random() * names.length)]}-${fieldIndex}`,
+      ...getRandomTypeAndDepth(fieldIndex),
+    })),
+  }));
+};
+
+export const useStressTestNodesAndEdges = (nodeCount: number) => {
   const [nodes, setNodes] = useState<NodeProps[]>([]);
   const [edges, setEdges] = useState<EdgeProps[]>([]);
 
   useEffect(() => {
-    const nodes = generateNodes(100);
-    const edges = generateEdges(nodes);
-
-    applyLayout<NodeProps, EdgeProps>(nodes, edges, 'STAR').then(result => {
-      setNodes(result.nodes);
-      setEdges(result.edges);
-    });
-  }, []);
-
-  const generateEdges = (nodes: NodeProps[]): EdgeProps[] => {
-    return nodes.map(node => ({
+    const newNodes = generateNodes(nodeCount);
+    const newEdges: EdgeProps[] = newNodes.map(node => ({
       id: `edge_${node.id}`,
-      source: nodes[Math.floor(Math.random() * nodes.length)].id,
-      target: nodes[Math.floor(Math.random() * nodes.length)].id,
+      source: newNodes[Math.floor(Math.random() * newNodes.length)].id,
+      target: newNodes[Math.floor(Math.random() * newNodes.length)].id,
       markerStart: 'many',
       markerEnd: 'one',
     }));
-  };
 
-  const generateNodes = (count: number): NodeProps[] => {
-    return Array.from(Array(count).keys()).map(i => ({
-      id: `node_${i}`,
-      type: 'table',
-      position: {
-        x: 0,
-        y: 0,
-      },
-      title: names[Math.floor(Math.random() * names.length)],
-      fields: Array.from(Array(1 + (i % 9)).keys()).map(_ => ({
-        name: names[Math.floor(Math.random() * names.length)],
-        type: 'varchar',
-      })),
-    }));
-  };
+    let applyUpdate = true;
+    applyLayout<NodeProps, EdgeProps>(newNodes, newEdges, 'STAR').then(result => {
+      if (!applyUpdate) return;
+      setNodes(result.nodes);
+      setEdges(result.edges);
+    });
+    return () => {
+      applyUpdate = false;
+    };
+  }, [nodeCount]);
+
+  return { nodes, edges };
+};
+
+export const DiagramStressTestDecorator: Decorator<DiagramProps> = (Story, context) => {
+  const { nodes, edges } = useStressTestNodesAndEdges(100);
 
   return Story({
     ...context,


### PR DESCRIPTION
<!-- Any segments that are not relevant to this pull request can be removed -->
## External Links

- :tickets: COMPASS-9767

## Description

Adds a stress test story that has the nodes editable.

## :camera_flash: Screenshots/Screencasts

<img width="1407" height="601" alt="Screenshot 2025-10-01 at 02 03 40" src="https://github.com/user-attachments/assets/a8054193-5382-4518-8eb2-ec4d67d76bb0" />
<img width="791" height="466" alt="Screenshot 2025-10-01 at 02 03 51" src="https://github.com/user-attachments/assets/e0e1fd4c-5f5c-453a-84f3-6bbacfa31cbc" />
