### PR TITLE
fix: better collapse icons

### DIFF
--- a/src/components/field/field-content.tsx
+++ b/src/components/field/field-content.tsx
@@ -1,7 +1,5 @@
 import styled from '@emotion/styled';
 import { fontWeights } from '@leafygreen-ui/tokens';
-import Icon from '@leafygreen-ui/icon';
-import { useTheme } from '@emotion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ellipsisTruncation } from '@/styles/styles';
@@ -10,6 +8,9 @@ import { FieldType } from '@/components/field/field-type';
 import { DiagramIconButton } from '@/components/buttons/diagram-icon-button';
 import { FieldId, NodeField } from '@/types';
 import { useEditableDiagramInteractions } from '@/hooks/use-editable-diagram-interactions';
+
+import { ChevronDown } from '../icons/chevron-down';
+import { ChevronUp } from '../icons/chevron-up';
 
 import { FieldNameContent } from './field-name-content';
 
@@ -46,7 +47,6 @@ export const FieldContent = ({
 }: FieldContentProps) => {
   const [isEditing, setIsEditing] = useState(false);
   const fieldContentRef = useRef<HTMLDivElement>(null);
-  const theme = useTheme();
 
   const { onChangeFieldName, onChangeFieldType, fieldTypes, onFieldExpandToggle } = useEditableDiagramInteractions();
 
@@ -137,7 +137,7 @@ export const FieldContent = ({
           aria-label={expanded ? 'Collapse Field' : 'Expand Field'}
           title={expanded ? 'Collapse Field' : 'Expand Field'}
         >
-          <Icon glyph={expanded ? 'ChevronDown' : 'ChevronLeft'} color={theme.node.fieldIconButton} size={14} />
+          {expanded ? <ChevronDown /> : <ChevronUp />}
         </DiagramIconButton>
       )}
     </FieldContentWrapper>

--- a/src/components/field/field-type.tsx
+++ b/src/components/field/field-type.tsx
@@ -15,7 +15,7 @@ const FieldTypeWrapper = styled.div<{ color: string; placeholderCollapse?: boole
   color: ${props => props.color};
   font-weight: normal;
   padding-left: ${spacing[100]}px;
-  padding-right: ${props => (props.placeholderCollapse ? spacing[600] : spacing[100])}px;
+  padding-right: ${props => (props.placeholderCollapse ? spacing[600] : spacing[50])}px;
   flex: 0 0 100px;
   display: flex;
   justify-content: flex-end;

--- a/src/components/icons/chevron-down.tsx
+++ b/src/components/icons/chevron-down.tsx
@@ -1,0 +1,20 @@
+import { useTheme } from '@emotion/react';
+
+export const ChevronDown = ({ size = 14 }: { size?: number }) => {
+  const theme = useTheme();
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0.005" y="0.005" width={size} height={size} stroke="black" strokeOpacity="0.01" strokeWidth="0.01" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M3.5 5.5l3.5 3.5 3.5-3.5"
+        stroke={theme.node.headerIcon}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+};

--- a/src/components/icons/chevron-up.tsx
+++ b/src/components/icons/chevron-up.tsx
@@ -1,0 +1,20 @@
+import { useTheme } from '@emotion/react';
+
+export const ChevronUp = ({ size = 14 }: { size?: number }) => {
+  const theme = useTheme();
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0.005" y="0.005" width={size} height={size} stroke="black" strokeOpacity="0.01" strokeWidth="0.01" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M3.5 8.5l3.5-3.5 3.5 3.5"
+        stroke={theme.node.headerIcon}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+};


### PR DESCRIPTION

## Description

### Before
<img width="779" height="294" alt="Screenshot 2026-01-27 at 11 39 40" src="https://github.com/user-attachments/assets/7c7622e5-87f8-4268-bf2e-642a88bbe7ca" />


### After
<img width="818" height="310" alt="Screenshot 2026-01-27 at 11 39 54" src="https://github.com/user-attachments/assets/ffad609a-f272-462a-be40-971cc347e3b7" />

