### PR TITLE
feature: Expose minimap props

### DIFF
--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -75,6 +75,7 @@ export const Canvas = ({
   onSelectionDragStop,
   onSelectionContextMenu,
   onSelectionChange,
+  minimapProps,
   ...rest
 }: DiagramProps) => {
   const initialNodes = useMemo(() => convertToInternalNodes(externalNodes), [externalNodes]);
@@ -192,7 +193,7 @@ export const Canvas = ({
           <MarkerList />
           <Background id={id} />
           <Controls title={title} />
-          <MiniMap />
+          <MiniMap {...minimapProps} />
         </ReactFlow>
       </ReactFlowWrapper>
     </EditableDiagramInteractionsProvider>

--- a/src/components/controls/mini-map.tsx
+++ b/src/components/controls/mini-map.tsx
@@ -1,10 +1,14 @@
 import { MiniMap as ReactFlowMiniMap } from '@xyflow/react';
 import { Theme, useTheme } from '@emotion/react';
 
+import { MiniMapProps } from '@/types';
+
 const MINIMAP_WIDTH = 200;
 const MINIMAP_HEIGHT = 100;
 
-export const MiniMap = () => {
+const EMPTY_PROPS = {};
+
+export const MiniMap = (minimapProps: MiniMapProps = EMPTY_PROPS) => {
   const theme: Theme = useTheme();
   return (
     <ReactFlowMiniMap
@@ -15,6 +19,7 @@ export const MiniMap = () => {
         height: MINIMAP_HEIGHT,
         background: theme.minimap.selectionArea,
       }}
+      {...minimapProps}
     />
   );
 };

--- a/src/components/diagram.stories.tsx
+++ b/src/components/diagram.stories.tsx
@@ -116,6 +116,10 @@ export const DiagramStressTest: Story = {
     isDarkMode: true,
     edges: [],
     nodes: [],
+    minimapProps: {
+      zoomable: true,
+      pannable: true,
+    },
   },
 };
 

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -110,6 +110,18 @@ export type OnConnectStartHandler = (
   params: { nodeId?: string | null; handleType: HandleType | null; handleId?: string | null },
 ) => void;
 
+export interface MiniMapProps {
+  /**
+   * Whether the minimap should allow panning the main view by dragging the viewport rectangle.
+   */
+  pannable?: boolean;
+
+  /**
+   * Whether the minimap should allow zooming the main view by clicking on the minimap.
+   */
+  zoomable?: boolean;
+}
+
 export interface DiagramProps {
   /**
    * Unique identifier for the diagram instance.
@@ -290,4 +302,9 @@ export interface DiagramProps {
    * @default 1
    */
   nodeDragThreshold?: number;
+
+  /**
+   * Preferences to pass to the minimap component.
+   */
+  minimapProps?: MiniMapProps;
 }


### PR DESCRIPTION
## Description

React Flow allows folks to have a pannable and zoomable minimap. We'd like to use those in Compass. This exposes those props. 
https://reactflow.dev/api-reference/components/minimap
