### PR TITLE
fix: expose panOnScroll mode COMPASS-10727

### DIFF
--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -289,6 +289,11 @@ export interface DiagramProps {
   minZoom?: number;
 
   /**
+   * Whether to allow panning via scroll.
+   */
+  panOnScroll?: boolean;
+
+  /**
    * Whether to only render elements that are currently visible in the viewport.
    * This can improve performance for large diagrams.
    * @default true


### PR DESCRIPTION

## Description

Exposing panOnScroll as an alternative to zoomOnScroll. This behaviour is more natural for diagramming libraries. 
Not changing the default here, leaving it to the client - we'll definitely make this switch in Compass, still waiting on reply from Schema migrator
